### PR TITLE
修改示例ReImplementInLua.cs中错误写法

### DIFF
--- a/Assets/XLua/Examples/12_ReImplementInLua/ReImplementInLua.cs
+++ b/Assets/XLua/Examples/12_ReImplementInLua/ReImplementInLua.cs
@@ -59,11 +59,13 @@ namespace XLuaTest
                 __index = function(o, k)
                     --print('__index', k)
                     if ins_methods[k] then return ins_methods[k] end
-                    return fields_getters[k] and fields_getters[k](o)
+                    assert(fields_getters[k],'no such field ' .. k)
+                    return fields_getters[k](o)
                 end,
 
                 __newindex = function(o, k, v)
-                    return fields_setters[k] and fields_setters[k](o, v) or error('no such field ' .. k)
+                    assert(fields_setters[k],'no such field ' .. k)
+                    return fields_setters[k](o, v)
                 end,
 
                 __tostring = function(o)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6984321/147718227-de1f1be8-7f89-4235-a7d5-fd5f46ba3840.png)
c 中 fields_setters 返回结果个数为0。 
lua ：condition and 空 or false 等同于 condition or false
即会执行修改的同时会触发error报错。

